### PR TITLE
Add primitive implementation

### DIFF
--- a/github_lines_viewed/borderify.js
+++ b/github_lines_viewed/borderify.js
@@ -1,1 +1,0 @@
-document.body.style.border = "5px solid red";

--- a/github_lines_viewed/lines-viewed.js
+++ b/github_lines_viewed/lines-viewed.js
@@ -28,7 +28,7 @@ function updateLinesRead(newRatio){
 function textReplacement() {
     const progressBar = document.querySelector('progress-bar');
     const progressBarText = progressBar.children[0].innerText;
-    const newProgressBarText = progressBarText.replace('file', 'line').replace('files', 'lines');
+    const newProgressBarText = progressBarText.replaceAll('file', 'line').replaceAll('files', 'lines');
     console.log(`newProgressBarText = ${newProgressBarText}`)
     progressBarText.innerText = newProgressBarText
 }

--- a/github_lines_viewed/lines-viewed.js
+++ b/github_lines_viewed/lines-viewed.js
@@ -1,0 +1,48 @@
+function updateLinesRead(){
+    console.log("updating lines!")
+    let changed_files = document.querySelectorAll('copilot-diff-entry');
+
+    let total_lines_changed = 0;
+    let lines_viewed = 0;
+
+    changed_files.forEach(changed_file => {
+        let file_lines_changed = Number(changed_file.querySelector('.diffstat').textContent)
+        total_lines_changed += file_lines_changed
+
+        let checkbox = changed_file.querySelector('input[type="checkbox"]')
+        if (checkbox.hasAttribute('checked')) {
+            lines_viewed += file_lines_changed
+        }
+    })
+
+    let progress_bar = document.querySelector('progress-bar');
+
+    let new_ratio = `${lines_viewed} / ${total_lines_changed}`
+
+    progress_bar.setAttribute('ratio', new_ratio)
+
+    let progress_bar_text = progress_bar.children[0].children[0];
+
+    progress_bar_text.innerText = progress_bar_text.innerText.replace('file', 'line').replace('files', 'lines');
+
+}
+
+function addCheckboxListeners(){
+    console.log("adding checkbox listeners")
+    let changed_files = document.querySelectorAll('copilot-diff-entry');
+
+    changed_files.forEach(changed_file => {
+        let checkbox = changed_file.querySelector('.js-replace-file-header-review')
+        checkbox.addEventListener('click', updateLinesRead)
+
+        let clickCount = 0;
+        checkbox.addEventListener('click', () => {
+            clickCount++;
+            console.log(`Button clicked ${clickCount} times`);
+        });
+
+    })
+}
+
+addCheckboxListeners()
+updateLinesRead()

--- a/github_lines_viewed/lines-viewed.js
+++ b/github_lines_viewed/lines-viewed.js
@@ -28,7 +28,7 @@ function updateLinesRead(newRatio){
 function textReplacement() {
     const progressBar = document.querySelector('progress-bar');
     const progressBarText = progressBar.children[0].innerText;
-    const newProgressBarText = progressBarText.replaceAll('file', 'line').replaceAll('files', 'lines');
+    const newProgressBarText = progressBarText.replaceAll('file', 'line');
     console.log(`newProgressBarText = ${newProgressBarText}`)
     progressBarText.innerText = newProgressBarText
 }

--- a/github_lines_viewed/lines-viewed.js
+++ b/github_lines_viewed/lines-viewed.js
@@ -1,48 +1,55 @@
-function updateLinesRead(){
-    console.log("updating lines!")
-    let changed_files = document.querySelectorAll('copilot-diff-entry');
+function getNewRatio(){
+    const changedFiles = document.querySelectorAll('copilot-diff-entry');
 
-    let total_lines_changed = 0;
-    let lines_viewed = 0;
+    let totalLinesChanged = 0;
+    let linesViewed = 0;
 
-    changed_files.forEach(changed_file => {
-        let file_lines_changed = Number(changed_file.querySelector('.diffstat').textContent)
-        total_lines_changed += file_lines_changed
+    changedFiles.forEach(changedFile => {
+        let fileLinesChanged = Number(changedFile.querySelector('.diffstat').textContent)
+        totalLinesChanged += fileLinesChanged
 
-        let checkbox = changed_file.querySelector('input[type="checkbox"]')
+        let checkbox = changedFile.querySelector('input[type="checkbox"]')
         if (checkbox.hasAttribute('checked')) {
-            lines_viewed += file_lines_changed
+            linesViewed += fileLinesChanged
         }
     })
 
-    let progress_bar = document.querySelector('progress-bar');
-
-    let new_ratio = `${lines_viewed} / ${total_lines_changed}`
-
-    progress_bar.setAttribute('ratio', new_ratio)
-
-    let progress_bar_text = progress_bar.children[0].children[0];
-
-    progress_bar_text.innerText = progress_bar_text.innerText.replace('file', 'line').replace('files', 'lines');
-
+    return `${linesViewed} / ${totalLinesChanged}`
 }
 
-function addCheckboxListeners(){
-    console.log("adding checkbox listeners")
-    let changed_files = document.querySelectorAll('copilot-diff-entry');
-
-    changed_files.forEach(changed_file => {
-        let checkbox = changed_file.querySelector('.js-replace-file-header-review')
-        checkbox.addEventListener('click', updateLinesRead)
-
-        let clickCount = 0;
-        checkbox.addEventListener('click', () => {
-            clickCount++;
-            console.log(`Button clicked ${clickCount} times`);
-        });
-
-    })
+function updateLinesRead(newRatio){
+    console.log(`Updating lines read: ${newRatio}`)
+    const progressBar = document.querySelector('progress-bar');
+    progressBar.setAttribute('ratio', newRatio)
+    progressBar.increment() // Creates an error, but still works
 }
 
-addCheckboxListeners()
-updateLinesRead()
+function textReplacement() {
+    const progressBar = document.querySelector('progress-bar');
+    const progressBarText = progressBar.children[0].innerText;
+    const newProgressBarText = progressBarText.replace('file', 'line').replace('files', 'lines');
+    console.log(`newProgressBarText = ${newProgressBarText}`)
+    progressBarText.innerText = newProgressBarText
+}
+
+const observer = new MutationObserver((mutations) => {
+    mutations.forEach(mutation => {
+        if (mutation.addedNodes.length) {
+            let newRatio = getNewRatio();
+            updateLinesRead(newRatio);
+            textReplacement();
+        }
+    });
+});
+
+const targetNode = document.querySelector('copilot-diff-entry').parentNode.parentNode;
+if (targetNode) {
+    observer.observe(targetNode, {
+        childList: true,
+        subtree: true
+    });
+}
+
+const firstNewRatio = getNewRatio();
+updateLinesRead(firstNewRatio);
+textReplacement();

--- a/github_lines_viewed/lines-viewed.js
+++ b/github_lines_viewed/lines-viewed.js
@@ -24,6 +24,7 @@ function updateLinesRead(newRatio){
     progressBar.increment() // Creates an error, but still works
 }
 
+// I don't think this ever runs since the progressBar.increment() fails (but works)
 function textReplacement() {
     const progressBar = document.querySelector('progress-bar');
     const progressBarText = progressBar.children[0].innerText;
@@ -50,6 +51,8 @@ if (targetNode) {
     });
 }
 
+// This only runs on a direct refresh or load of a PR /files URL not if coming
+// from a different part of the PR.
 const firstNewRatio = getNewRatio();
 updateLinesRead(firstNewRatio);
 textReplacement();

--- a/github_lines_viewed/manifest.json
+++ b/github_lines_viewed/manifest.json
@@ -13,7 +13,11 @@
   "content_scripts": [
     {
       "matches": ["*://github.com/*/*/pull/*/files"],
-      "js": ["borderify.js"]
+      "js": ["lines-viewed.js"]
     }
+  ],
+
+  "permissions": [
+    "activeTab"
   ]
 }


### PR DESCRIPTION
This adds barebones functionality to the extension. There are two known bugs with this:
- The text does not update from 'files' to 'lines' and I think this is because the script is actually crashing when calling `.increment()` as it's not recognised as a method, since it belongs to GitHub and isn't defined in my code
- It only seems to run on a page refresh, rather than clicking to the 'files' page from another area of the PR