### PR TITLE
Fix issue having to reload browser to run script when navigating to /files

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  tabWidth: 2,
+  semi: false,
+  singleQuote: false,
+};

--- a/github_lines_viewed/lines-viewed.js
+++ b/github_lines_viewed/lines-viewed.js
@@ -1,15 +1,17 @@
 function getNewRatio() {
-  const changedFiles = document.querySelectorAll('copilot-diff-entry');
+  const changedFiles = document.querySelectorAll("copilot-diff-entry")
 
-  let totalLinesChanged = 0;
-  let linesViewed = 0;
+  let totalLinesChanged = 0
+  let linesViewed = 0
 
-  changedFiles.forEach(changedFile => {
-    let fileLinesChanged = Number(changedFile.querySelector('.diffstat').textContent)
+  changedFiles.forEach((changedFile) => {
+    let fileLinesChanged = Number(
+      changedFile.querySelector(".diffstat").textContent
+    )
     totalLinesChanged += fileLinesChanged
 
     let checkbox = changedFile.querySelector('input[type="checkbox"]')
-    if (checkbox.hasAttribute('checked')) {
+    if (checkbox.hasAttribute("checked")) {
       linesViewed += fileLinesChanged
     }
   })
@@ -18,37 +20,50 @@ function getNewRatio() {
 }
 
 function updateLinesRead(newRatio) {
-  const progressBar = document.querySelector('progress-bar');
-  progressBar.setAttribute('ratio', newRatio)
+  const progressBar = document.querySelector("progress-bar")
+  progressBar.setAttribute("ratio", newRatio)
 }
 
 function textReplacement() {
-  const progressBarText = document.querySelector('progress-bar').children[0].children[0].lastChild;
-  progressBarText.data = progressBarText.data.replaceAll('file', 'line');
+  const progressBarText =
+    document.querySelector("progress-bar").children[0].children[0].lastChild
+  progressBarText.data = progressBarText.data.replaceAll("file", "line")
 }
 
 function runScript() {
-  let newRatio = getNewRatio();
-  updateLinesRead(newRatio);
-  textReplacement();
+  let newRatio = getNewRatio()
+  updateLinesRead(newRatio)
+  textReplacement()
 }
 
 const checkboxObserver = new MutationObserver((mutations) => {
-  mutations.forEach(mutation => {
+  mutations.forEach((mutation) => {
     if (mutation.addedNodes.length) {
-      runScript();
+      runScript()
     }
-  });
-});
+  })
+})
 
-const targetNode = document.querySelector('copilot-diff-entry').parentNode.parentNode;
-if (targetNode) {
-  checkboxObserver.observe(targetNode, {
-    childList: true,
-    subtree: true
-  });
-}
+// Run script when URL changes to end with "/files"
+let previousUrl = ""
+const observer = new MutationObserver(() => {
+  const targetNode =
+    document.querySelector("copilot-diff-entry")?.parentNode?.parentNode
+  if (targetNode) {
+    checkboxObserver.observe(targetNode, {
+      childList: true,
+      subtree: true,
+    })
 
-// This only runs on a direct refresh or load of a PR /files URL not if coming
-// from a different part of the PR.
-runScript();
+    if (location.href !== previousUrl) {
+      previousUrl = location.href
+      console.log(`URL changed to ${location.href}`)
+
+      if (location.href.endsWith("/files")) {
+        console.log("run script")
+        runScript()
+      }
+    }
+  }
+})
+observer.observe(document, { subtree: true, childList: true })

--- a/github_lines_viewed/manifest.json
+++ b/github_lines_viewed/manifest.json
@@ -2,24 +2,21 @@
   "manifest_version": 2,
   "name": "GitHub Lines Viewed",
   "version": "0.1.3",
-
   "description": "Replaces GitHub's 'files viewed' with 'lines viewed' instead.",
-
   "icons": {
     "48": "icons/48.png",
     "96": "icons/96.png"
   },
-
   "content_scripts": [
     {
       "matches": [
-        "*://github.com/*/*/pull/*/files",
-        "*://github.com/*/*/pull/*/files/*"
+        "*://github.com/*"
       ],
-      "js": ["lines-viewed.js"]
+      "js": [
+        "lines-viewed.js"
+      ]
     }
   ],
-
   "permissions": [
     "activeTab"
   ]


### PR DESCRIPTION
This PR fixes the bug of having to reload the browser on the files tab to run the script.

- Added prettier config for formatting
- Updated manifest matches for all GitHub URLs
- Listen to URL changes and only run script if URL ends with `/files`