### PR TITLE
Fix binary files breaking progress bar

### DIFF
--- a/src/lines-viewed.js
+++ b/src/lines-viewed.js
@@ -8,6 +8,11 @@ function getNewRatio() {
     let fileLinesChanged = Number(
       changedFile.querySelector(".diffstat").textContent
     )
+
+    if (isNaN(fileLinesChanged)) {
+      fileLinesChanged = 1
+    }
+
     totalLinesChanged += fileLinesChanged
 
     let checkbox = changedFile.querySelector('input[type="checkbox"]')

--- a/src/lines-viewed.js
+++ b/src/lines-viewed.js
@@ -57,10 +57,8 @@ const observer = new MutationObserver(() => {
 
     if (location.href !== previousUrl) {
       previousUrl = location.href
-      console.log(`URL changed to ${location.href}`)
 
       if (location.href.endsWith("/files")) {
-        console.log("run script")
         runScript()
       }
     }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "GitHub Lines Viewed",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Replaces GitHub's 'files viewed' with 'lines viewed' instead.",
   "icons": {
     "48": "icons/48.png",


### PR DESCRIPTION
- Removes logging that is no longer needed
- Fixes #11 

The code treats binary files as a single 'line' of code to be reviewed. This behaviour was chosen for 2 reasons:
1. It prevents unclean behaviour where ticking the file adds +1 and then it is removed again
2. You will still need to tick all files (acknowledge them) for a full progress bar.