### PR TITLE
Remove unnecessary permission

### DIFF
--- a/manifest-chrome.json
+++ b/manifest-chrome.json
@@ -12,6 +12,5 @@
       "matches": ["*://github.com/*"],
       "js": ["lines-viewed.js"]
     }
-  ],
-  "permissions": ["activeTab"]
+  ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,6 @@
       "js": ["lines-viewed.js"]
     }
   ],
-  "permissions": ["activeTab"],
   "browser_specific_settings": {
     "gecko": {
       "id": "{1f27e2d0-740c-46eb-978a-9c119bc60371}"


### PR DESCRIPTION
Chrome store rejected the extension because of overpermissioning.